### PR TITLE
moving modalOptions enums to utils folder

### DIFF
--- a/frontend/src/app/components/Card.tsx
+++ b/frontend/src/app/components/Card.tsx
@@ -1,5 +1,6 @@
 import { ethers, utils } from "ethers";
-import { Occasion, modalOptions } from "../page";
+import { Occasion } from "../page";
+import { modalOptions } from "@/utils/modalOptions";
 
 interface CardProps {
   id: number;

--- a/frontend/src/app/components/Sort.tsx
+++ b/frontend/src/app/components/Sort.tsx
@@ -1,5 +1,5 @@
+import { modalOptions } from "@/utils/modalOptions";
 import React from "react";
-import { modalOptions } from "../page";
 
 const sortOptions = [
   "Select Your Genre",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,6 +4,7 @@ import { ethers, providers, BigNumber } from "ethers";
 import { useState, useEffect } from "react";
 import { NETWORK_CONFIG, TOKENMASTER_CONTRACT_ABI } from "../../constants";
 import { Card, Navbar, Sort, SeatChart, Modal } from "./components";
+import { modalOptions } from "@/utils/modalOptions";
 
 export interface Occasion {
   id: BigNumber;
@@ -14,11 +15,6 @@ export interface Occasion {
   date: string;
   time: string;
   location: string;
-}
-
-export enum modalOptions {
-  addEvent = "Add Event",
-  viewSeats = "View Seats",
 }
 
 const Home = () => {

--- a/frontend/src/utils/modalOptions.ts
+++ b/frontend/src/utils/modalOptions.ts
@@ -1,0 +1,4 @@
+export enum modalOptions {
+  addEvent = "Add Event",
+  viewSeats = "View Seats",
+}


### PR DESCRIPTION
adding modalOptions enum to utils as Vercel does not allow enum as valid Page export field