### PR TITLE
migrating from use of ethers in page.tsx to use of wagmi/viem incrementally

### DIFF
--- a/frontend/constants/index.ts
+++ b/frontend/constants/index.ts
@@ -9,6 +9,23 @@ export const NETWORK_CONFIG: { [key: string]: { address: string } } = {
   },
 };
 
+export enum NetworkName {
+  LOCALHOST = "localhost",
+  SEPOLIA = "sepolia",
+}
+
+export const networkChain = {
+  "0x7a69": NetworkName.LOCALHOST,
+  "0xaa36a7": NetworkName.SEPOLIA,
+};
+
+export type NetworkOption = keyof typeof networkChain;
+
+export const NetworkOptions = {
+  [NetworkName.LOCALHOST]: "0x5FbDB2315678afecb367f032d93F642f64180aa3", 
+  [NetworkName.SEPOLIA]: "0xcB342B0eb3AA8cAdd4cC883E42805a813B3aEBDB", 
+}
+
 export const TOKENMASTER_CONTRACT_ABI = [
   {
     inputs: [

--- a/frontend/src/app/components/Card.tsx
+++ b/frontend/src/app/components/Card.tsx
@@ -1,6 +1,6 @@
-import { ethers, utils } from "ethers";
 import { Occasion } from "../page";
 import { modalOptions } from "@/utils/modalOptions";
+import { formatUnits } from "viem";
 
 interface CardProps {
   id: number;
@@ -37,7 +37,7 @@ const Card: React.FC<CardProps> = ({
         </p>
         <div className='col-span-1 row-span-2 self-center text-base sm:text-3xl font-light'>
           <p className="font-semibold">
-            {utils.formatUnits(occasion.cost.toString(), "ether")}
+            {formatUnits(occasion.cost, 18)}
           </p>{" "}
           ETH
         </div>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- slowly transitioning from ethers to wagmi/viem
- converting from ethers Providers/Signers terminology to WalletClient/PublicClient
- updating constants to handle grabbing hex string of chainId from window.ethereum.chainId
- updating typing of Occasion in page.tsx which also changes Occasion.cost within Cards.tsx