### PR TITLE
Ethers to viem migration frontend

### DIFF
--- a/backend/hardhat.config.ts
+++ b/backend/hardhat.config.ts
@@ -14,6 +14,9 @@ const config: HardhatUserConfig = {
       url: QUICKNODE_HTTP_URL,
       accounts: [PRIVATE_KEY!],
     },
+    hardhat: {
+      chainId: 1337,
+    },
   },
   etherscan: {
     apiKey: {

--- a/frontend/constants/index.ts
+++ b/frontend/constants/index.ts
@@ -1,30 +1,19 @@
-export const NETWORK_CONFIG: { [key: string]: { address: string } } = {
-  // localhost
-  "31337": {
-    address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-  },
-  // sepolia
-  "11155111": {
-    address: "0xcB342B0eb3AA8cAdd4cC883E42805a813B3aEBDB",
-  },
-};
-
-export enum NetworkName {
+enum NetworkName {
   LOCALHOST = "localhost",
   SEPOLIA = "sepolia",
 }
 
 export const networkChain = {
-  "0x7a69": NetworkName.LOCALHOST,
+  "0x539": NetworkName.LOCALHOST,
   "0xaa36a7": NetworkName.SEPOLIA,
 };
 
 export type NetworkOption = keyof typeof networkChain;
 
 export const NetworkOptions = {
-  [NetworkName.LOCALHOST]: "0x5FbDB2315678afecb367f032d93F642f64180aa3", 
-  [NetworkName.SEPOLIA]: "0xcB342B0eb3AA8cAdd4cC883E42805a813B3aEBDB", 
-}
+  [NetworkName.LOCALHOST]: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+  [NetworkName.SEPOLIA]: "0xcB342B0eb3AA8cAdd4cC883E42805a813B3aEBDB",
+};
 
 export const TOKENMASTER_CONTRACT_ABI = [
   {

--- a/frontend/globals.d.ts
+++ b/frontend/globals.d.ts
@@ -1,0 +1,7 @@
+import { MetaMaskInpageProvider } from "@metamask/providers";
+
+declare global {
+  interface Window {
+    ethereum: MetaMaskInpageProvider;
+  }
+}

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { ethers } from 'ethers';
+import { Address } from 'viem';
 import Link from 'next/link';
 
 interface NavbarProps {
-  account: string | null;
-  setAccount: (account: string) => void;
+  account: Address | null;
+  setAccount: (account: Address) => void;
 }
 
 const Navbar: React.FC<NavbarProps> = ({ account, setAccount }) => {
@@ -13,7 +14,7 @@ const Navbar: React.FC<NavbarProps> = ({ account, setAccount }) => {
       method: 'eth_requestAccounts',
     });
     const account = ethers.utils.getAddress(accounts[0]);
-    setAccount(account);
+    setAccount(account as `0x${string}`);
   };
 
   return (

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -9,7 +9,7 @@ interface NavbarProps {
 
 const Navbar: React.FC<NavbarProps> = ({ account, setAccount }) => {
   const connectHandler = async () => {
-    const accounts = await (window as any).ethereum.request({
+    const accounts = await window.ethereum.request({
       method: 'eth_requestAccounts',
     });
     const account = ethers.utils.getAddress(accounts[0]);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -70,22 +70,22 @@ const Home = () => {
   };
 
   const loadBlockchainData = async () => {
-    const provider = new providers.Web3Provider((window as any).ethereum);
+    const provider = new providers.Web3Provider(window.ethereum);
 
-    console.log("chain: ", (window as any).ethereum.chainId);
+    console.log("chain: ", window.ethereum.chainId);
 
-    const chainId2 = (window as any).ethereum.chainId as NetworkOption;
+    const chainId2 = window.ethereum.chainId as NetworkOption;
 
     const publicClient = createPublicClient({
       chain: mappedNetworkChain(chainId2),
-      transport: custom((window as any).ethereum),
+      transport: custom(window.ethereum),
     });
 
     setPublicClient(publicClient);
 
     const walletClient = createWalletClient({
       chain: mappedNetworkChain(chainId2),
-      transport: custom((window as any).ethereum),
+      transport: custom(window.ethereum),
     });
 
     setWalletClient(walletClient);
@@ -126,8 +126,8 @@ const Home = () => {
 
     setOccasions(occasions);
 
-    (window as any).ethereum.on("accountsChanged", async () => {
-      const accounts = await (window as any).ethereum.request({
+    window.ethereum.on("accountsChanged", async () => {
+      const accounts = await window.ethereum.request({
         method: "eth_requestAccounts",
       });
       const account = getAddress(accounts[0]);
@@ -187,7 +187,7 @@ const Home = () => {
   useEffect(() => {
     const fetchContractOwner = async () => {
       if (publicClient && account !== null) {
-        const chainId2 = (window as any).ethereum.chainId as NetworkOption;
+        const chainId2 = window.ethereum.chainId as NetworkOption;
 
         const wagmiContractConfig = {
           abi: TOKENMASTER_CONTRACT_ABI,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { ethers, providers } from "ethers";
 import {
+  Address,
   createPublicClient,
   createWalletClient,
   custom,
@@ -10,11 +11,9 @@ import {
 } from "viem";
 import { useState, useEffect } from "react";
 import {
-  NETWORK_CONFIG,
   NetworkOptions,
   NetworkOption,
   networkChain,
-  NetworkName,
   TOKENMASTER_CONTRACT_ABI,
 } from "../../constants";
 import {
@@ -26,7 +25,8 @@ import {
   CreateEvent,
 } from "./components";
 import { modalOptions } from "@/utils/modalOptions";
-import { localhost, sepolia } from "wagmi/chains";
+import { localhost, sepolia } from "viem/chains";
+import useLoadBlockchainData from "@/utils/useLoadBlockchainData";
 
 export interface Occasion {
   id: bigint;
@@ -40,11 +40,10 @@ export interface Occasion {
 }
 
 const Home = () => {
-  const [account, setAccount] = useState<string | null>(null);
+  const [account, setAccount] = useState<Address | null>(null);
   const [provider, setProvider] = useState<providers.Web3Provider | null>(null);
   const [publicClient, setPublicClient] = useState<any | null>(null);
   const [walletClient, setWalletClient] = useState<any | null>(null);
-  const [occasions, setOccasions] = useState<Occasion[]>([]);
   const [occasion, setOccasion] = useState<Occasion | null>(null);
   const [toggle, setToggle] = useState<boolean>(false);
   const [tokenMasterContract, setTokenMasterContract] =
@@ -58,73 +57,72 @@ const Home = () => {
   const [contractListenerAdded, setContractListenerAdded] =
     useState<boolean>(false);
 
-  const mappedNetworkChain = (chainId: NetworkOption) => {
-    switch (networkChain[chainId]) {
-      case NetworkName.LOCALHOST:
-        return localhost;
-      case NetworkName.SEPOLIA:
-        return sepolia;
-      default:
-        return;
-    }
+  const { occasions } = useLoadBlockchainData();
+
+  const mappedChain = {
+    "0x539": localhost,
+    "0xaa36a7": sepolia,
   };
 
   const loadBlockchainData = async () => {
-    const provider = new providers.Web3Provider(window.ethereum);
+    // const provider = new providers.Web3Provider(window.ethereum);
 
     console.log("chain: ", window.ethereum.chainId);
 
-    const chainId2 = window.ethereum.chainId as NetworkOption;
+    const chainId = window.ethereum.chainId as NetworkOption;
 
     const publicClient = createPublicClient({
-      chain: mappedNetworkChain(chainId2),
+      chain: mappedChain[chainId],
       transport: custom(window.ethereum),
     });
 
     setPublicClient(publicClient);
 
+    const [account] = await window.ethereum.request({
+      method: "eth_requestAccounts",
+    });
+
     const walletClient = createWalletClient({
-      chain: mappedNetworkChain(chainId2),
+      account,
+      chain: mappedChain[chainId],
       transport: custom(window.ethereum),
     });
 
     setWalletClient(walletClient);
 
-    const [address] = await walletClient.getAddresses();
-
     const wagmiContractConfig = {
       abi: TOKENMASTER_CONTRACT_ABI,
-      address: NetworkOptions[networkChain[chainId2]] as `0x${string}`,
+      address: NetworkOptions[networkChain[chainId]] as `0x${string}`,
     };
 
-    setProvider(provider);
+    // setProvider(provider);
 
-    const { chainId } = await provider.getNetwork();
+    // const { chainId } = await provider.getNetwork();
 
-    const tokenMasterContract = new ethers.Contract(
-      NETWORK_CONFIG[chainId.toString()].address,
-      TOKENMASTER_CONTRACT_ABI,
-      provider,
-    );
-    setTokenMasterContract(tokenMasterContract);
+    // const tokenMasterContract = new ethers.Contract(
+    //   NETWORK_CONFIG[chainId.toString()].address,
+    //   TOKENMASTER_CONTRACT_ABI,
+    //   provider,
+    // );
+    // setTokenMasterContract(tokenMasterContract);
 
-    const supply = (await publicClient.readContract({
-      ...wagmiContractConfig,
-      functionName: "totalOccasions",
-    })) as bigint;
+    // const totalOccasions = (await publicClient.readContract({
+    //   ...wagmiContractConfig,
+    //   functionName: "totalOccasions",
+    // })) as bigint;
 
-    const occasions: Occasion[] = [];
+    // const occasions: Occasion[] = [];
 
-    for (let i = 1n; i <= Number(supply); i++) {
-      const singleOccasion = await publicClient.readContract({
-        ...wagmiContractConfig,
-        functionName: "getOccasion",
-        args: [i],
-      });
-      occasions.push(singleOccasion as Occasion);
-    }
+    // for (let i = 1n; i <= Number(totalOccasions); i++) {
+    //   const singleOccasion = await publicClient.readContract({
+    //     ...wagmiContractConfig,
+    //     functionName: "getOccasion",
+    //     args: [i],
+    //   });
+    //   occasions.push(singleOccasion as Occasion);
+    // }
 
-    setOccasions(occasions);
+    // setOccasions(occasions);
 
     window.ethereum.on("accountsChanged", async () => {
       const accounts = await window.ethereum.request({
@@ -158,8 +156,8 @@ const Home = () => {
       case modalOptions.addEvent:
         return (
           <CreateEvent
-            tokenMasterContract={tokenMasterContract!}
-            provider={provider!}
+            publicClient={publicClient}
+            walletClient={walletClient}
           />
         );
 
@@ -172,26 +170,26 @@ const Home = () => {
     loadBlockchainData();
   }, [account]);
 
-  useEffect(() => {
-    if (tokenMasterContract && !contractListenerAdded) {
-      tokenMasterContract.on("OccasionCreated", async (occasionId) => {
-        const occasion: Occasion = await tokenMasterContract.getOccasion(
-          occasionId,
-        );
-        setOccasions((prevOccasions) => [...prevOccasions, occasion]);
-      });
-      setContractListenerAdded(true);
-    }
-  }, [tokenMasterContract, contractListenerAdded]);
+  // useEffect(() => {
+  //   if (tokenMasterContract && !contractListenerAdded) {
+  //     tokenMasterContract.on("OccasionCreated", async (occasionId) => {
+  //       const occasion: Occasion = await tokenMasterContract.getOccasion(
+  //         occasionId,
+  //       );
+  //       setOccasions((prevOccasions) => [...prevOccasions, occasion]);
+  //     });
+  //     setContractListenerAdded(true);
+  //   }
+  // }, [tokenMasterContract, contractListenerAdded]);
 
   useEffect(() => {
     const fetchContractOwner = async () => {
       if (publicClient && account !== null) {
-        const chainId2 = window.ethereum.chainId as NetworkOption;
+        const chainId = window.ethereum.chainId as NetworkOption;
 
         const wagmiContractConfig = {
           abi: TOKENMASTER_CONTRACT_ABI,
-          address: NetworkOptions[networkChain[chainId2]] as `0x${string}`,
+          address: NetworkOptions[networkChain[chainId]] as `0x${string}`,
         };
         // const contractOwner = await tokenMasterContract.owner();
         const contractOwner = await publicClient.readContract({

--- a/frontend/src/utils/useLoadBlockchainData.tsx
+++ b/frontend/src/utils/useLoadBlockchainData.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Address,
+  createPublicClient,
+  createWalletClient,
+  custom,
+  getAddress,
+  isAddressEqual,
+} from "viem";
+import {
+  NetworkOptions,
+  NetworkOption,
+  networkChain,
+  TOKENMASTER_CONTRACT_ABI,
+} from "../../constants";
+import { localhost, sepolia } from "viem/chains";
+
+export interface Occasion {
+  id: bigint;
+  name: string;
+  cost: bigint;
+  tickets: bigint;
+  maxTickets: bigint;
+  date: string;
+  time: string;
+  location: string;
+}
+
+const useLoadBlockchainData = () => {
+  const [account, setAccount] = useState<Address>();
+  const [occasions, setOccasions] = useState<Occasion[]>([]);
+  const [occasion, setOccasion] = useState<Occasion | null>(null);
+  const [contractOwnerConnected, setContractOwnerConnected] =
+    useState<boolean>(false);
+
+  const mappedChain = {
+    "0x539": localhost,
+    "0xaa36a7": sepolia,
+  };
+
+  const loadBlockchainData = async () => {
+    const chainId = window.ethereum.chainId as NetworkOption;
+
+    const wagmiContractConfig = {
+      abi: TOKENMASTER_CONTRACT_ABI,
+      address: NetworkOptions[networkChain[chainId]] as `0x${string}`,
+    };
+
+    const [connectedAccount] = await window.ethereum.request({
+      method: "eth_requestAccounts",
+    });
+
+    const publicClient = createPublicClient({
+      chain: mappedChain[chainId],
+      transport: custom(window.ethereum),
+    });
+
+    const walletClient = createWalletClient({
+      account: connectedAccount,
+      chain: mappedChain[chainId],
+      transport: custom(window.ethereum),
+    });
+
+    const totalOccasions = (await publicClient.readContract({
+      ...wagmiContractConfig,
+      functionName: "totalOccasions",
+    })) as bigint;
+
+    const fetchedOccasions: Occasion[] = [];
+
+    for (let i = 1n; i <= Number(totalOccasions); i++) {
+      const singleOccasion = await publicClient.readContract({
+        ...wagmiContractConfig,
+        functionName: "getOccasion",
+        args: [i],
+      });
+      fetchedOccasions.push(singleOccasion as Occasion);
+    }
+
+    setOccasions(fetchedOccasions);
+
+    window.ethereum.on("accountsChanged", async () => {
+      const accounts = await window.ethereum.request({
+        method: "eth_requestAccounts",
+      });
+      const account = getAddress(accounts[0]);
+      setAccount(account);
+    });
+  };
+
+  useEffect(() => {
+    loadBlockchainData();
+  }, [account]);
+
+  return {occasions};
+};
+
+export default useLoadBlockchainData;


### PR DESCRIPTION
- modifying constants as viem/chains expects 1337 for localhost chainId,
- changing hardhat.config within backend to have chainId related to hh node blockchain use 1337 chainId
- introducing custom hook for useLoadBlockchainData and migrating logic of loading blockchain data upon changing account, 
- slowly phasing out use of ethers dependency with use of wagmi and viem which works with listing new occasions within Cards
- working on migrating more code away from ethers to wagmi/viem as well as separating blockchain related data from state data that is needed between components but not needed for blockchain related functionality