### PR TITLE
Ethers to viem migration frontend

### DIFF
--- a/frontend/src/app/components/CreateEvent.tsx
+++ b/frontend/src/app/components/CreateEvent.tsx
@@ -2,16 +2,11 @@ import React, { useState, useEffect } from "react";
 import CircularProgress from "@mui/material/CircularProgress";
 import { TOKENMASTER_CONTRACT_ABI } from "../../../constants";
 import { parseUnits } from "viem";
+import useLoadBlockchainData from "@/utils/useLoadBlockchainData";
 
-interface CreateEventProps {
-  publicClient: any;
-  walletClient: any;
-}
+const CreateEvent: React.FC = () => {
+  const { publicClient, walletClient } = useLoadBlockchainData();
 
-const CreateEvent: React.FC<CreateEventProps> = ({
-  publicClient,
-  walletClient,
-}) => {
   const [inputs, setInputs] = useState({
     name: "",
     cost: "",
@@ -46,10 +41,9 @@ const CreateEvent: React.FC<CreateEventProps> = ({
     e.preventDefault();
 
     try {
-
       setLoadingTx(true);
 
-      const { request } = await publicClient.simulateContract({
+      const { request } = await publicClient!.simulateContract({
         address: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
         abi: TOKENMASTER_CONTRACT_ABI,
         functionName: "list",
@@ -63,12 +57,12 @@ const CreateEvent: React.FC<CreateEventProps> = ({
         ],
       });
 
-      console.log('request: ', request)
-      await walletClient.writeContract(request);
+      console.log("request: ", request);
+      await walletClient!.writeContract(request);
 
       setLoadingTx(false);
     } catch (err) {
-    setLoadingTx(false);
+      setLoadingTx(false);
       console.error(err);
     }
   };

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -10,7 +10,7 @@ interface NavbarProps {
 
 const Navbar: React.FC<NavbarProps> = ({ account, setAccount }) => {
   const connectHandler = async () => {
-    const accounts = await window!.ethereum.request({
+    const accounts = await window.ethereum.request({
       method: 'eth_requestAccounts',
     });
     const account = getAddress(accounts[0]);

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -10,7 +10,7 @@ interface NavbarProps {
 
 const Navbar: React.FC<NavbarProps> = ({ account, setAccount }) => {
   const connectHandler = async () => {
-    const accounts = await window.ethereum.request({
+    const accounts = await window!.ethereum.request({
       method: 'eth_requestAccounts',
     });
     const account = getAddress(accounts[0]);

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -2,13 +2,11 @@ import React from 'react';
 import { ethers } from 'ethers';
 import { Address } from 'viem';
 import Link from 'next/link';
+import useLoadBlockchainData from '@/utils/useLoadBlockchainData';
 
-interface NavbarProps {
-  account: Address | null;
-  setAccount: (account: Address) => void;
-}
 
-const Navbar: React.FC<NavbarProps> = ({ account, setAccount }) => {
+const Navbar: React.FC = () => {
+  const { account, setAccount } = useLoadBlockchainData();
   const connectHandler = async () => {
     const accounts = await window.ethereum.request({
       method: 'eth_requestAccounts',

--- a/frontend/src/app/components/Navbar.tsx
+++ b/frontend/src/app/components/Navbar.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import { ethers } from 'ethers';
-import { Address } from 'viem';
+import { Address, getAddress } from 'viem';
 import Link from 'next/link';
-import useLoadBlockchainData from '@/utils/useLoadBlockchainData';
+
+interface NavbarProps {
+  account: Address;
+  setAccount: (account: Address) => void;
+}
 
 
-const Navbar: React.FC = () => {
-  const { account, setAccount } = useLoadBlockchainData();
+const Navbar: React.FC<NavbarProps> = ({ account, setAccount }) => {
   const connectHandler = async () => {
     const accounts = await window.ethereum.request({
       method: 'eth_requestAccounts',
     });
-    const account = ethers.utils.getAddress(accounts[0]);
-    setAccount(account as `0x${string}`);
+    const account = getAddress(accounts[0]);
+    setAccount(account);
   };
 
   return (

--- a/frontend/src/app/components/Sort.tsx
+++ b/frontend/src/app/components/Sort.tsx
@@ -9,13 +9,13 @@ const sortOptions = [
 ];
 
 interface SortProps {
+  contractOwnerConnected: boolean;
   setModalContent: (addEvent: modalOptions.addEvent) => void;
   toggle: any;
   setToggle: (toggle: boolean) => void;
 }
 
-const Sort: React.FC<SortProps> = ({ setModalContent, toggle, setToggle }) => {
-  const { contractOwnerConnected } = useLoadBlockchainData();
+const Sort: React.FC<SortProps> = ({ setModalContent, toggle, setToggle, contractOwnerConnected }) => {
   const togglePop = () => {
     setModalContent(modalOptions.addEvent)
     toggle ? setToggle(false) : setToggle(true);

--- a/frontend/src/app/components/Sort.tsx
+++ b/frontend/src/app/components/Sort.tsx
@@ -1,4 +1,5 @@
 import { modalOptions } from "@/utils/modalOptions";
+import useLoadBlockchainData from "@/utils/useLoadBlockchainData";
 import React from "react";
 
 const sortOptions = [
@@ -8,13 +9,13 @@ const sortOptions = [
 ];
 
 interface SortProps {
-  contractOwnerConnected: boolean;
   setModalContent: (addEvent: modalOptions.addEvent) => void;
   toggle: any;
   setToggle: (toggle: boolean) => void;
 }
 
-const Sort: React.FC<SortProps> = ({ contractOwnerConnected, setModalContent, toggle, setToggle }) => {
+const Sort: React.FC<SortProps> = ({ setModalContent, toggle, setToggle }) => {
+  const { contractOwnerConnected } = useLoadBlockchainData();
   const togglePop = () => {
     setModalContent(modalOptions.addEvent)
     toggle ? setToggle(false) : setToggle(true);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { ethers, providers } from "ethers";
-import {
-  Address,
-  createPublicClient,
-  createWalletClient,
-  custom,
-  getAddress,
-  isAddressEqual,
-} from "viem";
+import { Address, isAddressEqual } from "viem";
 import { useState, useEffect } from "react";
 import {
   NetworkOptions,
@@ -25,7 +18,6 @@ import {
   CreateEvent,
 } from "./components";
 import { modalOptions } from "@/utils/modalOptions";
-import { localhost, sepolia } from "viem/chains";
 import useLoadBlockchainData from "@/utils/useLoadBlockchainData";
 
 export interface Occasion {
@@ -40,16 +32,11 @@ export interface Occasion {
 }
 
 const Home = () => {
-  const [account, setAccount] = useState<Address | null>(null);
   const [provider, setProvider] = useState<providers.Web3Provider | null>(null);
-  const [publicClient, setPublicClient] = useState<any | null>(null);
-  const [walletClient, setWalletClient] = useState<any | null>(null);
   const [occasion, setOccasion] = useState<Occasion | null>(null);
   const [toggle, setToggle] = useState<boolean>(false);
   const [tokenMasterContract, setTokenMasterContract] =
     useState<ethers.Contract | null>(null);
-  const [contractOwnerConnected, setContractOwnerConnected] =
-    useState<boolean>(false);
   const [contractBalance, setContractBalance] = useState<string>("0");
   const [modalContent, setModalContent] = useState<modalOptions>(
     modalOptions.addEvent,
@@ -57,81 +44,7 @@ const Home = () => {
   const [contractListenerAdded, setContractListenerAdded] =
     useState<boolean>(false);
 
-  const { occasions } = useLoadBlockchainData();
-
-  const mappedChain = {
-    "0x539": localhost,
-    "0xaa36a7": sepolia,
-  };
-
-  const loadBlockchainData = async () => {
-    // const provider = new providers.Web3Provider(window.ethereum);
-
-    console.log("chain: ", window.ethereum.chainId);
-
-    const chainId = window.ethereum.chainId as NetworkOption;
-
-    const publicClient = createPublicClient({
-      chain: mappedChain[chainId],
-      transport: custom(window.ethereum),
-    });
-
-    setPublicClient(publicClient);
-
-    const [account] = await window.ethereum.request({
-      method: "eth_requestAccounts",
-    });
-
-    const walletClient = createWalletClient({
-      account,
-      chain: mappedChain[chainId],
-      transport: custom(window.ethereum),
-    });
-
-    setWalletClient(walletClient);
-
-    const wagmiContractConfig = {
-      abi: TOKENMASTER_CONTRACT_ABI,
-      address: NetworkOptions[networkChain[chainId]] as `0x${string}`,
-    };
-
-    // setProvider(provider);
-
-    // const { chainId } = await provider.getNetwork();
-
-    // const tokenMasterContract = new ethers.Contract(
-    //   NETWORK_CONFIG[chainId.toString()].address,
-    //   TOKENMASTER_CONTRACT_ABI,
-    //   provider,
-    // );
-    // setTokenMasterContract(tokenMasterContract);
-
-    // const totalOccasions = (await publicClient.readContract({
-    //   ...wagmiContractConfig,
-    //   functionName: "totalOccasions",
-    // })) as bigint;
-
-    // const occasions: Occasion[] = [];
-
-    // for (let i = 1n; i <= Number(totalOccasions); i++) {
-    //   const singleOccasion = await publicClient.readContract({
-    //     ...wagmiContractConfig,
-    //     functionName: "getOccasion",
-    //     args: [i],
-    //   });
-    //   occasions.push(singleOccasion as Occasion);
-    // }
-
-    // setOccasions(occasions);
-
-    window.ethereum.on("accountsChanged", async () => {
-      const accounts = await window.ethereum.request({
-        method: "eth_requestAccounts",
-      });
-      const account = getAddress(accounts[0]);
-      setAccount(account);
-    });
-  };
+  const { occasions, contractOwnerConnected } = useLoadBlockchainData();
 
   const fetchBalance = async () => {
     if (tokenMasterContract && provider) {
@@ -154,21 +67,12 @@ const Home = () => {
           />
         );
       case modalOptions.addEvent:
-        return (
-          <CreateEvent
-            publicClient={publicClient}
-            walletClient={walletClient}
-          />
-        );
+        return <CreateEvent />;
 
       default:
         return;
     }
   };
-
-  useEffect(() => {
-    loadBlockchainData();
-  }, [account]);
 
   // useEffect(() => {
   //   if (tokenMasterContract && !contractListenerAdded) {
@@ -182,37 +86,10 @@ const Home = () => {
   //   }
   // }, [tokenMasterContract, contractListenerAdded]);
 
-  useEffect(() => {
-    const fetchContractOwner = async () => {
-      if (publicClient && account !== null) {
-        const chainId = window.ethereum.chainId as NetworkOption;
-
-        const wagmiContractConfig = {
-          abi: TOKENMASTER_CONTRACT_ABI,
-          address: NetworkOptions[networkChain[chainId]] as `0x${string}`,
-        };
-        // const contractOwner = await tokenMasterContract.owner();
-        const contractOwner = await publicClient.readContract({
-          ...wagmiContractConfig,
-          functionName: "owner",
-        });
-
-        isAddressEqual(contractOwner, account as `0x${string}`)
-          ? setContractOwnerConnected(true)
-          : setContractOwnerConnected(false);
-      }
-    };
-
-    fetchContractOwner();
-  }, [tokenMasterContract, account]);
-
   return (
     <>
       <header className='bg-gradient-banner from-indigo-900 via-blue-500 to-indigo-900 min-h-[25vh] relative'>
-        <Navbar
-          account={account}
-          setAccount={setAccount}
-        />
+        <Navbar />
         <div className='absolute bottom-5 left-20 text-white text-2xl sm:text-5xl md:text-3xl font-light'>
           {contractOwnerConnected && (
             <h3>Contract Balance: {contractBalance} ETH</h3>
@@ -225,7 +102,6 @@ const Home = () => {
 
       <div className='items-center max-w-7xl h-75 mx-auto relative transition-all duration-250 ease'>
         <Sort
-          contractOwnerConnected={contractOwnerConnected}
           setModalContent={setModalContent}
           toggle={toggle}
           setToggle={setToggle}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,14 +1,7 @@
 "use client";
 
 import { ethers, providers } from "ethers";
-import { Address, isAddressEqual } from "viem";
-import { useState, useEffect } from "react";
-import {
-  NetworkOptions,
-  NetworkOption,
-  networkChain,
-  TOKENMASTER_CONTRACT_ABI,
-} from "../../constants";
+import { useState } from "react";
 import {
   Card,
   Navbar,
@@ -41,10 +34,16 @@ const Home = () => {
   const [modalContent, setModalContent] = useState<modalOptions>(
     modalOptions.addEvent,
   );
-  const [contractListenerAdded, setContractListenerAdded] =
-    useState<boolean>(false);
 
-  const { occasions, contractOwnerConnected } = useLoadBlockchainData();
+  const {
+    account,
+    setAccount,
+    occasions,
+    contractOwnerConnected,
+    publicClient,
+    walletClient,
+    address,
+  } = useLoadBlockchainData();
 
   const fetchBalance = async () => {
     if (tokenMasterContract && provider) {
@@ -67,29 +66,26 @@ const Home = () => {
           />
         );
       case modalOptions.addEvent:
-        return <CreateEvent />;
+        return (
+          <CreateEvent
+            publicClient={publicClient!}
+            walletClient={walletClient!}
+            address={address}
+          />
+        );
 
       default:
         return;
     }
   };
 
-  // useEffect(() => {
-  //   if (tokenMasterContract && !contractListenerAdded) {
-  //     tokenMasterContract.on("OccasionCreated", async (occasionId) => {
-  //       const occasion: Occasion = await tokenMasterContract.getOccasion(
-  //         occasionId,
-  //       );
-  //       setOccasions((prevOccasions) => [...prevOccasions, occasion]);
-  //     });
-  //     setContractListenerAdded(true);
-  //   }
-  // }, [tokenMasterContract, contractListenerAdded]);
-
   return (
     <>
       <header className='bg-gradient-banner from-indigo-900 via-blue-500 to-indigo-900 min-h-[25vh] relative'>
-        <Navbar />
+        <Navbar
+          account={account as `0x${string}`}
+          setAccount={setAccount}
+        />
         <div className='absolute bottom-5 left-20 text-white text-2xl sm:text-5xl md:text-3xl font-light'>
           {contractOwnerConnected && (
             <h3>Contract Balance: {contractBalance} ETH</h3>
@@ -105,6 +101,7 @@ const Home = () => {
           setModalContent={setModalContent}
           toggle={toggle}
           setToggle={setToggle}
+          contractOwnerConnected={contractOwnerConnected}
         />
       </div>
 

--- a/frontend/src/utils/useLoadBlockchainData.tsx
+++ b/frontend/src/utils/useLoadBlockchainData.tsx
@@ -43,23 +43,28 @@ const useLoadBlockchainData = () => {
   const [walletClient, setWalletClient] = useState<WalletClientType>();
   const [contractListenerAdded, setContractListenerAdded] =
     useState<boolean>(false);
+  const [wagmiContractConfig, setwagmiContractConfig] = useState<any>({});
 
   const mappedChain = {
     "0x539": localhost,
     "0xaa36a7": sepolia,
   };
 
-  const chainId = window!.ethereum.chainId as NetworkOption;
-
-  const wagmiContractConfig = {
-    abi: TOKENMASTER_CONTRACT_ABI,
-    address: NetworkOptions[networkChain[chainId]] as `0x${string}`,
-  };
-
   const loadBlockchainData = async () => {
+    const chainId = window.ethereum.chainId as NetworkOption;
+
+    const wagmiContractConfig = {
+      abi: TOKENMASTER_CONTRACT_ABI,
+      address: NetworkOptions[networkChain[chainId]] as `0x${string}`,
+    };
+
+    setwagmiContractConfig({
+      ...wagmiContractConfig,
+    });
+
     const publicClient = createPublicClient({
       chain: mappedChain[chainId],
-      transport: custom(window!.ethereum),
+      transport: custom(window.ethereum),
     });
 
     setPublicClient(publicClient);
@@ -68,7 +73,7 @@ const useLoadBlockchainData = () => {
       const walletClient = createWalletClient({
         account: account !== null ? account : undefined,
         chain: mappedChain[chainId],
-        transport: custom(window!.ethereum),
+        transport: custom(window.ethereum),
       });
       setWalletClient(walletClient);
     }
@@ -106,8 +111,8 @@ const useLoadBlockchainData = () => {
         : setContractOwnerConnected(false);
     }
 
-    window!.ethereum.on("accountsChanged", async () => {
-      const accounts = await window!.ethereum.request({
+    window.ethereum.on("accountsChanged", async () => {
+      const accounts = await window.ethereum.request({
         method: "eth_requestAccounts",
       });
       const account = getAddress(accounts[0]);
@@ -137,7 +142,7 @@ const useLoadBlockchainData = () => {
 
       setContractListenerAdded(true);
     }
-  }, [publicClient, contractListenerAdded]);
+  }, [publicClient, wagmiContractConfig, contractListenerAdded]);
 
   return {
     account,
@@ -146,7 +151,7 @@ const useLoadBlockchainData = () => {
     contractOwnerConnected,
     publicClient,
     walletClient,
-    address: wagmiContractConfig.address,
+    address: wagmiContractConfig?.address,
   };
 };
 

--- a/frontend/src/utils/useLoadBlockchainData.tsx
+++ b/frontend/src/utils/useLoadBlockchainData.tsx
@@ -49,7 +49,7 @@ const useLoadBlockchainData = () => {
     "0xaa36a7": sepolia,
   };
 
-  const chainId = window.ethereum.chainId as NetworkOption;
+  const chainId = window!.ethereum.chainId as NetworkOption;
 
   const wagmiContractConfig = {
     abi: TOKENMASTER_CONTRACT_ABI,
@@ -59,7 +59,7 @@ const useLoadBlockchainData = () => {
   const loadBlockchainData = async () => {
     const publicClient = createPublicClient({
       chain: mappedChain[chainId],
-      transport: custom(window.ethereum),
+      transport: custom(window!.ethereum),
     });
 
     setPublicClient(publicClient);
@@ -68,7 +68,7 @@ const useLoadBlockchainData = () => {
       const walletClient = createWalletClient({
         account: account !== null ? account : undefined,
         chain: mappedChain[chainId],
-        transport: custom(window.ethereum),
+        transport: custom(window!.ethereum),
       });
       setWalletClient(walletClient);
     }
@@ -106,8 +106,8 @@ const useLoadBlockchainData = () => {
         : setContractOwnerConnected(false);
     }
 
-    window.ethereum.on("accountsChanged", async () => {
-      const accounts = await window.ethereum.request({
+    window!.ethereum.on("accountsChanged", async () => {
+      const accounts = await window!.ethereum.request({
         method: "eth_requestAccounts",
       });
       const account = getAddress(accounts[0]);


### PR DESCRIPTION
- migrating more code away from ethers to viem
- reverting back to prop drilling as custom hook was being invoked more than the intended single time upon loading an account
- cleaning up code along the way that is no longer in use or has been moved elsewhere
- adding a Union intersection of Log within useLoadBlockchainData as TypeScript was unable to recognize that the use of viem watchContractEvent logs has an args within the return with the desired emitted log information
- adding conditional logic for hoisting account param to createWalletClient within useLoadBlockchainData hook as the account itself is unknown until the user either connects his/her account or switches an account; this address/walletClient so far is only necessary for confirming that the deployer of contract is connected and for 'listing' an occasion which only the contract owner can do