### PR TITLE
Ethers to viem migration frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,6 @@
         "@types/react": "18.2.8",
         "@types/react-dom": "18.2.4",
         "autoprefixer": "10.4.14",
-        "ethers": "^5.7.2",
         "next": "13.4.4",
         "postcss": "8.4.24",
         "react": "18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,6 @@
     "@types/react": "18.2.8",
     "@types/react-dom": "18.2.4",
     "autoprefixer": "10.4.14",
-    "ethers": "^5.7.2",
     "next": "13.4.4",
     "postcss": "8.4.24",
     "react": "18.2.0",

--- a/frontend/src/app/components/Seat.tsx
+++ b/frontend/src/app/components/Seat.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { BigNumber } from "ethers";
 
 interface SeatProps {
   i: number;
@@ -26,7 +25,7 @@ const Seat: React.FC<SeatProps> = ({
     <div
       onClick={() => buyHandler(i + step)}
       className={
-        seatsTaken.find((seat: BigNumber) => Number(seat) == i + step)
+        seatsTaken.find((seat: bigint) => Number(seat) == i + step)
           ? "text-center bg-red-400 text-white border border-black rounded-full text-sm cursor-pointer transition duration-250 ease-in-out w-7 h-7"
           : "text-center bg-blue-900 text-white border border-black rounded-full text-sm cursor-pointer transition duration-250 ease-in-out w-7 h-7"
       }

--- a/frontend/src/app/components/Sort.tsx
+++ b/frontend/src/app/components/Sort.tsx
@@ -1,5 +1,4 @@
 import { modalOptions } from "@/utils/modalOptions";
-import useLoadBlockchainData from "@/utils/useLoadBlockchainData";
 import React from "react";
 
 const sortOptions = [

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { ethers, providers } from "ethers";
 import { useState } from "react";
 import {
   Card,
@@ -25,12 +24,8 @@ export interface Occasion {
 }
 
 const Home = () => {
-  const [provider, setProvider] = useState<providers.Web3Provider | null>(null);
   const [occasion, setOccasion] = useState<Occasion | null>(null);
   const [toggle, setToggle] = useState<boolean>(false);
-  const [tokenMasterContract, setTokenMasterContract] =
-    useState<ethers.Contract | null>(null);
-  const [contractBalance, setContractBalance] = useState<string>("0");
   const [modalContent, setModalContent] = useState<modalOptions>(
     modalOptions.addEvent,
   );
@@ -43,15 +38,9 @@ const Home = () => {
     publicClient,
     walletClient,
     address,
+    wagmiContractConfig,
+    contractBalance,
   } = useLoadBlockchainData();
-
-  const fetchBalance = async () => {
-    if (tokenMasterContract && provider) {
-      const balance = await provider.getBalance(tokenMasterContract.address);
-      const formattedBalance = ethers.utils.formatEther(balance);
-      setContractBalance(formattedBalance);
-    }
-  };
 
   const displayModalContent = () => {
     switch (modalContent) {
@@ -59,10 +48,11 @@ const Home = () => {
         return (
           <SeatChart
             occasion={occasion!}
-            tokenMasterContract={tokenMasterContract!}
-            provider={provider!}
+            publicClient={publicClient!}
+            walletClient={walletClient!}
+            address={address}
+            wagmiContractConfig={wagmiContractConfig}
             setToggle={setToggle}
-            fetchBalance={fetchBalance}
           />
         );
       case modalOptions.addEvent:

--- a/frontend/src/utils/useLoadBlockchainData.tsx
+++ b/frontend/src/utils/useLoadBlockchainData.tsx
@@ -9,6 +9,7 @@ import {
   getAddress,
   isAddressEqual,
   Log,
+  formatUnits,
 } from "viem";
 import {
   NetworkOptions,
@@ -44,6 +45,7 @@ const useLoadBlockchainData = () => {
   const [contractListenerAdded, setContractListenerAdded] =
     useState<boolean>(false);
   const [wagmiContractConfig, setwagmiContractConfig] = useState<any>({});
+  const [contractBalance, setContractBalance] = useState<string>("0");
 
   const mappedChain = {
     "0x539": localhost,
@@ -69,18 +71,18 @@ const useLoadBlockchainData = () => {
 
     setPublicClient(publicClient);
 
-    if (account) {
-      const walletClient = createWalletClient({
-        account: account !== null ? account : undefined,
-        chain: mappedChain[chainId],
-        transport: custom(window.ethereum),
-      });
-      setWalletClient(walletClient);
-    }
+    const walletClient = createWalletClient({
+      account: account !== null ? account : undefined,
+      chain: mappedChain[chainId],
+      transport: custom(window.ethereum),
+    });
+    setWalletClient(walletClient);
 
     const balance = await publicClient.getBalance({
       address: wagmiContractConfig.address,
     });
+
+    setContractBalance(formatUnits(balance, 18));
 
     const totalOccasions = (await publicClient.readContract({
       ...wagmiContractConfig,
@@ -151,7 +153,9 @@ const useLoadBlockchainData = () => {
     contractOwnerConnected,
     publicClient,
     walletClient,
+    wagmiContractConfig,
     address: wagmiContractConfig?.address,
+    contractBalance,
   };
 };
 


### PR DESCRIPTION
- Refactored SeatChart component to use viem methods for reserving a seat instead of using ethers methods
- Cleaned up all components that had remnants of use of ethers
- Added contractBalance state within useLoadBlockchainData hook
- Removed ethers dependency from frontend